### PR TITLE
feat(kit): make `disabled` non-optional in calendar options

### DIFF
--- a/libs/kit/components/calendar/options.ts
+++ b/libs/kit/components/calendar/options.ts
@@ -17,8 +17,8 @@ export interface XCalendarOptions {
   readonly radius: XUnion<'none' | 'sm' | 'md' | 'lg' | 'full'>;
   readonly weekdayFormat: XWeekdayFormat;
   readonly monthFormat: XMonthFormat;
+  readonly disabled: Mapper<Date, boolean>;
   readonly detail?: Mapper<Date, any>;
-  readonly disabled?: Mapper<Date, boolean>;
 }
 
 const defaultOptions: XCalendarOptions = {
@@ -30,6 +30,7 @@ const defaultOptions: XCalendarOptions = {
   radius: 'md',
   weekdayFormat: 'min',
   monthFormat: 'short',
+  disabled: () => false,
 };
 
 export const X_CALENDAR_OPTIONS = new InjectionToken<XCalendarOptions>('CALENDAR_OPTIONS', {


### PR DESCRIPTION
Closes: # <!-- Related issue number -->

## Summary

Make `disabled` property non-optional in calendar options (`XCalendarOptions`)