### PR TITLE
ci: remove `self-hosted` runner from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,6 @@ jobs:
   version:
     name: Publish new version
     timeout-minutes: 5
-    runs-on: self-hosted
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
## Notes

Remove the use of a self runner due to the lack of necessity when deploying via public npm and gh pages