### PR TITLE
feat(kit): add support for reduced motion preference in collapsible styles

### DIFF
--- a/libs/kit/components/collapsible/collapsible.scss
+++ b/libs/kit/components/collapsible/collapsible.scss
@@ -9,6 +9,10 @@
     grid-template-rows: 1fr;
     opacity: 1;
   }
+
+  @media (prefers-reduced-motion) {
+    transition-duration: 0ms;
+  }
 }
 
 .x-collapsible-content {


### PR DESCRIPTION
## What changed

```css
.x-collapsible {
  display: grid;
  grid-template-rows: 0fr;
  overflow: hidden;
  opacity: 0;
  transition: grid-template-rows 200ms ease-in-out 1ms, opacity 200ms ease-in-out;

  &:where([data-state='open']) {
    grid-template-rows: 1fr;
    opacity: 1;
  }

  + @media (prefers-reduced-motion) {
  +  transition-duration: 0ms;
  + }
}
```